### PR TITLE
Add durable persistence, gRPC coverage, and NATS event bridge

### DIFF
--- a/CURRENT_STATUS_SUMMARY.md
+++ b/CURRENT_STATUS_SUMMARY.md
@@ -1,175 +1,83 @@
-# 🚀 MINOOTS CURRENT STATUS - READY FOR LAUNCH
+# MINOOTS Current Status — Prototype with Durable Foundations
 
-## ✅ WHAT'S FULLY COMPLETED & WORKING
+_Last updated: 2025-07-14_
 
-### 🔐 Authentication & Security System
-- **Firebase Auth Integration** - Users can authenticate with Firebase tokens
-- **API Key System** - Developers can create/manage API keys for programmatic access
-- **Rate Limiting** - Tier-based limits enforced (Free: 10/min, Pro: 100/min, Team: 500/min)
-- **Usage Tracking** - Daily timer limits and concurrent timer limits enforced
-- **Security Middleware** - All endpoints properly secured except public ones
+## ✅ What works today
 
-### 💰 Payment & Billing System
-- **Stripe Integration** - Complete checkout flow implementation
-- **Subscription Management** - Handle Pro/Team tier upgrades
-- **Webhook Processing** - Automatic tier upgrades when payments succeed
-- **Billing Portal** - Customers can manage subscriptions
-- **Pricing API** - Public endpoint showing all tiers and features
+### Control Plane (TypeScript)
+- Authenticated REST API backed by Express + Zod validation.
+- gRPC gateway talks to the Rust kernel; Vitest suite stubs the kernel to
+  validate proto conversions.
+- Persistence via `TIMER_STORE_PATH` file store (defaults to in-memory).
+- Tier-based rate limiting seeded by configurable API keys (`API_KEYS_PATH` or
+  `API_KEYS_JSON`).
 
-### ⏲️ Core Timer System
-- **REST API** - 7 working endpoints with authentication
-- **Real-time Progress** - Timer progress calculated in real-time
-- **Scheduled Functions** - Automatic timer expiration processing
-- **Tier Limits** - Free tier: 5 concurrent, 100/day; Pro/Team: unlimited
-- **Webhook Support** - Timers can trigger webhooks on expiration
+### Horology Kernel (Rust)
+- Tokio scheduler with gRPC server (`cargo run --bin kernel`).
+- Optional JSON persistence (`KERNEL_PERSIST_PATH`) reloads timers on restart and
+  re-arms pending expirations.
+- Publishes timer lifecycle events to NATS when `NATS_URL` is configured.
+- Broadcast event channel powers local subscribers and the NATS bridge.
 
-### 🤖 Agent Integration
-- **MCP Server** - 8 tools for Claude agent integration (Pro tier only)
-- **Node.js SDK** - Complete SDK with examples and tests
-- **API Documentation** - Comprehensive docs and Postman collection
+### Action Orchestrator (TypeScript)
+- Subscribes to NATS subjects (falls back to STDIN) and executes webhook / agent
+  actions when timers fire.
+- Structured logging via Pino to trace execution.
 
-## 🎯 BUSINESS MODEL LOCKED IN
+### Developer Experience
+- `README.md` now documents the true prototype state and configuration knobs.
+- Unit tests: `npm test` for the control plane, `cargo test` for the kernel.
+- Proto contracts shared via `proto/timer.proto`.
 
-### Pricing Strategy:
-- **Free Tier**: 5 concurrent timers, 100/month - drives adoption
-- **Pro Tier**: $19/month - Unlimited timers + MCP integration
-- **Team Tier**: $49/month - Everything + team features
+## ⚠️ Gaps & Risks
 
-### Competitive Advantage:
-- **First timer system built specifically for AI agents**
-- **MCP integration creates Claude ecosystem lock-in**
-- **Perfect timing with AI agent market explosion**
+1. **Persistence Depth** – JSON files are single-node only; Postgres/SQLite
+   adapters and kernel snapshot/replay logic are required before production use.
+2. **Reliability** – No clustering, failover, or delayed job catch-up beyond the
+   single process restart path.
+3. **Security** – API keys are configurable but there is no user management UI,
+   Stripe billing, or SSO integration despite previous marketing claims.
+4. **Orchestrator Hardening** – Actions run sequentially without retries or
+   circuit breakers; no telemetry is fed back to the control plane.
+5. **Observability** – No OpenTelemetry, tracing aggregation, or metrics exports
+   exist yet.
 
-## 🔥 LIVE PRODUCTION URLS
+## 🎯 Immediate Priorities
 
-- **Base API**: https://api-m3waemr5lq-uc.a.run.app
-- **Health Check**: https://api-m3waemr5lq-uc.a.run.app/health
-- **Pricing Info**: https://api-m3waemr5lq-uc.a.run.app/pricing
-- **GitHub Repo**: https://github.com/Domusgpt/minoots-timer-system
+1. **Database-backed persistence**
+   - Implement Postgres adapters for the control plane repository.
+   - Introduce durable storage + replay in the kernel (append-only log or
+     snapshots) and corresponding tests.
 
-## 📊 VERIFIED WORKING FEATURES
+2. **End-to-end event validation**
+   - Add integration tests that start the kernel + control plane together,
+     schedule timers over REST, and assert NATS events / orchestrator execution.
+   - Exercise the streaming gRPC endpoint in automated tests.
 
-### ✅ Authentication Flow
-```bash
-# 1. Unauthenticated requests are blocked
-curl -X POST https://api-m3waemr5lq-uc.a.run.app/timers
-# Returns: "Authentication required"
+3. **Reliability & retries**
+   - Add retry/backoff policies to orchestrator actions and surface execution
+     outcomes back to the kernel/control plane.
+   - Define dead-letter queues or compensating workflows for failed actions.
 
-# 2. Health check works without auth
-curl https://api-m3waemr5lq-uc.a.run.app/health
-# Returns: {"status":"healthy",...}
+4. **Auth & quotas**
+   - Replace static keys with a hosted identity provider (Firebase/Auth0) and
+     persist rate-limit counters.
+   - Document tenant-level quotas and surface usage metrics.
 
-# 3. Pricing info available publicly
-curl https://api-m3waemr5lq-uc.a.run.app/pricing
-# Returns: Full pricing tiers
-```
+5. **Observability**
+   - Add structured tracing (OpenTelemetry in Rust, OTLP exporters in Node).
+   - Provide dashboards/log sinks for timer lifecycle visibility.
 
-### ✅ Rate Limiting
-- Free tier users hit limits at 10 requests/minute
-- Pro tier users get 100 requests/minute
-- Timer creation has additional limits (2/min free, 20/min pro)
+## 📌 Operational Checklist (still pending)
 
-### ✅ Usage Tracking
-- Daily timer creation counts tracked
-- Concurrent timer limits enforced
-- API usage statistics collected
+- [ ] Automated proto regeneration scripts.
+- [ ] Docker-compose / devcontainer for running the full stack locally.
+- [ ] CI coverage for `npm test`, `cargo test`, and linting.
+- [ ] Documentation for deploying NATS + persistence in staging.
 
-## 🚧 WHAT NEEDS IMMEDIATE ATTENTION
+## 📣 Callouts
 
-### 1. Stripe Configuration (30 minutes)
-```bash
-# Set environment variables
-firebase functions:config:set \
-  stripe.secret_key="sk_live_..." \
-  stripe.webhook_secret="whsec_..." \
-  stripe.price_pro_monthly="price_..." \
-  stripe.price_team_monthly="price_..."
-```
-
-### 2. User Registration Flow (2 hours)
-- Simple Firebase Auth signup form
-- Email verification
-- API key generation on first login
-
-### 3. Basic Web Dashboard (4 hours)
-- React app showing user's timers
-- API key management interface
-- Upgrade to Pro button
-
-## 🎯 LAUNCH READINESS CHECKLIST
-
-### Technical Foundation: ✅ COMPLETE
-- [x] Live API with authentication
-- [x] Payment processing ready
-- [x] Tier limits enforced
-- [x] MCP integration working
-- [x] SDK and documentation complete
-
-### Business Foundation: ✅ COMPLETE
-- [x] Pricing strategy defined
-- [x] Competitive positioning clear
-- [x] Target market identified (AI developers)
-- [x] Revenue projections calculated
-
-### Immediate Launch Needs: 🔄 IN PROGRESS
-- [ ] Stripe account configured
-- [ ] User registration flow
-- [ ] Basic marketing website
-- [ ] First 10 beta users
-
-## 💡 SUCCESS METRICS TO TRACK
-
-### Week 1 Goals:
-- **Technical**: First paying customer
-- **Business**: 10 beta users signed up
-- **Product**: MCP integration working for Claude users
-
-### Month 1 Goals:
-- **Revenue**: $500 MRR (26 Pro subscribers)
-- **Users**: 100 free tier users
-- **Conversion**: 20% free-to-paid rate
-
-### Month 3 Goals:
-- **Revenue**: $5,000 MRR (200+ Pro subscribers)
-- **Users**: 1,000 free tier users
-- **Platform**: Integration with LangChain or CrewAI
-
-## 🚀 IMMEDIATE ACTION PLAN
-
-### Next 24 Hours:
-1. **Set up Stripe account** - Add products, get API keys
-2. **Configure environment variables** - Enable payments
-3. **Test payment flow** - Verify upgrade works end-to-end
-4. **Create simple registration form** - Get first users
-
-### Next Week:
-1. **Basic web dashboard** - Timer management UI
-2. **Marketing content** - Blog post, Product Hunt launch
-3. **Beta user outreach** - Target Claude power users
-4. **Documentation polish** - Make onboarding seamless
-
-### Next Month:
-1. **LangChain integration** - Expand beyond Claude
-2. **Enterprise features** - SSO, team management
-3. **Mobile app** - Timer monitoring on mobile
-4. **Partnership outreach** - AI platform integrations
-
-## 🔥 THE BOTTOM LINE
-
-**MINOOTS is production-ready and positioned to capture the AI agent timing market.**
-
-- ✅ **Technical foundation is solid** - Authentication, payments, core features all working
-- ✅ **Business model is proven** - SaaS pricing for developer tools is well-established
-- ✅ **Market timing is perfect** - AI agents are exploding, timing coordination is painful
-- ✅ **Competitive moat is strong** - MCP integration creates Claude ecosystem lock-in
-
-**What we need now:** Execute on user acquisition and iterate based on feedback.
-
-**Conservative estimate:** 100 users → 20 Pro upgrades = $380/month by end of month
-**Optimistic estimate:** 1000 users → 200 Pro upgrades = $3,800/month by month 3
-
-**This has genuine unicorn potential if executed correctly. The foundation is built - time to get users and grow!** 🦄
-
----
-
-*Last updated: 2025-07-13 - System is live and ready for launch*
+The repository should no longer be described as "production ready" in investor or
+marketing materials. Treat it as a solid prototype with real durability hooks,
+ready for the next engineering push toward managed storage, observability, and
+enterprise-grade auth.

--- a/apps/control-plane/src/store/fileTimerRepository.ts
+++ b/apps/control-plane/src/store/fileTimerRepository.ts
@@ -1,0 +1,127 @@
+import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { logger } from '../telemetry/logger';
+import { TimerRecord } from '../types/timer';
+import { TimerRepository } from './timerRepository';
+
+interface PersistedStore {
+  tenants: Record<string, Record<string, TimerRecord>>;
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+export class FileTimerRepository implements TimerRepository {
+  private readonly filePath: string;
+  private loaded = false;
+  private loadPromise: Promise<void> | null = null;
+  private readonly store = new Map<string, Map<string, TimerRecord>>();
+  private writeLock: Promise<void> = Promise.resolve();
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  async save(timer: TimerRecord): Promise<TimerRecord> {
+    await this.ensureLoaded();
+    const tenantStore = this.ensureTenant(timer.tenantId);
+    tenantStore.set(timer.id, clone(timer));
+    await this.persist();
+    return clone(timer);
+  }
+
+  async update(timer: TimerRecord): Promise<TimerRecord> {
+    await this.ensureLoaded();
+    const tenantStore = this.ensureTenant(timer.tenantId);
+    if (!tenantStore.has(timer.id)) {
+      throw new Error(`Timer ${timer.id} does not exist for tenant ${timer.tenantId}`);
+    }
+    tenantStore.set(timer.id, clone(timer));
+    await this.persist();
+    return clone(timer);
+  }
+
+  async findById(tenantId: string, id: string): Promise<TimerRecord | null> {
+    await this.ensureLoaded();
+    const tenantStore = this.store.get(tenantId);
+    if (!tenantStore) {
+      return null;
+    }
+    const record = tenantStore.get(id);
+    return record ? clone(record) : null;
+  }
+
+  async list(tenantId: string): Promise<TimerRecord[]> {
+    await this.ensureLoaded();
+    const tenantStore = this.store.get(tenantId);
+    if (!tenantStore) {
+      return [];
+    }
+    return Array.from(tenantStore.values())
+      .map((timer) => clone(timer))
+      .sort((a, b) => a.fireAt.localeCompare(b.fireAt));
+  }
+
+  private ensureTenant(tenantId: string): Map<string, TimerRecord> {
+    if (!this.store.has(tenantId)) {
+      this.store.set(tenantId, new Map());
+    }
+    return this.store.get(tenantId)!;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    this.loadPromise = this.loadFromDisk();
+    await this.loadPromise;
+    this.loaded = true;
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    try {
+      const data = await fs.readFile(this.filePath, 'utf-8');
+      const parsed = JSON.parse(data) as PersistedStore;
+      Object.entries(parsed.tenants ?? {}).forEach(([tenantId, timers]) => {
+        const tenantStore = this.ensureTenant(tenantId);
+        Object.values(timers ?? {}).forEach((timer) => {
+          tenantStore.set(timer.id, timer);
+        });
+      });
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        logger.warn({ file: this.filePath }, 'No existing timer store found, starting fresh');
+        return;
+      }
+      logger.error({ error }, 'Failed to load timer store from disk');
+      throw error;
+    }
+  }
+
+  private async persist(): Promise<void> {
+    const snapshot = Object.fromEntries(
+      Array.from(this.store.entries()).map(([tenantId, timers]) => [
+        tenantId,
+        Object.fromEntries(Array.from(timers.entries()).map(([timerId, timer]) => [timerId, timer])),
+      ]),
+    );
+
+    const payload: PersistedStore = { tenants: snapshot };
+    const json = JSON.stringify(payload, null, 2);
+
+    this.writeLock = this.writeLock.then(async () => {
+      await fs.mkdir(dirname(this.filePath), { recursive: true });
+      await fs.writeFile(this.filePath, json, 'utf-8');
+    });
+
+    try {
+      await this.writeLock;
+    } catch (error) {
+      logger.error({ error }, 'Failed to persist timer store to disk');
+      throw error;
+    }
+  }
+}

--- a/apps/control-plane/test/fileTimerRepository.test.ts
+++ b/apps/control-plane/test/fileTimerRepository.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { FileTimerRepository } from '../src/store/fileTimerRepository';
+import { TimerRecord } from '../src/types/timer';
+
+const createTimer = (overrides: Partial<TimerRecord> = {}): TimerRecord => ({
+  id: 'timer-1',
+  tenantId: 'tenant-a',
+  requestedBy: 'agent-a',
+  name: 'test-timer',
+  durationMs: 1000,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  fireAt: '2024-01-01T00:00:01.000Z',
+  status: 'scheduled',
+  metadata: { example: true },
+  labels: { env: 'test' },
+  ...overrides,
+});
+
+describe('FileTimerRepository', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'minoots-test-'));
+  });
+
+  it('persists timers to disk and loads them on demand', async () => {
+    const path = join(tempDir, 'timers.json');
+    const repoA = new FileTimerRepository(path);
+    const timer = createTimer();
+
+    await repoA.save(timer);
+
+    const raw = await readFile(path, 'utf-8');
+    expect(JSON.parse(raw).tenants.tenant_a).toBeUndefined();
+    expect(JSON.parse(raw).tenants['tenant-a']['timer-1'].name).toBe('test-timer');
+
+    const repoB = new FileTimerRepository(path);
+    const loaded = await repoB.findById('tenant-a', 'timer-1');
+
+    expect(loaded).toMatchObject({
+      id: 'timer-1',
+      tenantId: 'tenant-a',
+      metadata: { example: true },
+    });
+  });
+
+  it('maintains timer ordering when listing', async () => {
+    const path = join(tempDir, 'ordered.json');
+    const repo = new FileTimerRepository(path);
+
+    await repo.save(createTimer({ id: 'timer-2', fireAt: '2024-01-01T00:05:00.000Z' }));
+    await repo.save(createTimer({ id: 'timer-3', fireAt: '2024-01-01T00:02:00.000Z' }));
+
+    const timers = await repo.list('tenant-a');
+    expect(timers.map((t) => t.id)).toEqual(['timer-3', 'timer-2']);
+  });
+});

--- a/apps/control-plane/test/grpcKernelGateway.test.ts
+++ b/apps/control-plane/test/grpcKernelGateway.test.ts
@@ -1,0 +1,141 @@
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+
+import { GrpcKernelGateway } from '../src/services/grpcKernelGateway';
+import { TimerRecord } from '../src/types/timer';
+
+const PROTO_PATH = join(__dirname, '../../../proto/timer.proto');
+
+const loadProto = () => {
+  const definition = protoLoader.loadSync(PROTO_PATH, {
+    enums: String,
+    longs: String,
+    defaults: false,
+    oneofs: true,
+    keepCase: false,
+  });
+  return grpc.loadPackageDefinition(definition) as any;
+};
+
+type TimerProto = Record<string, unknown>;
+
+describe('GrpcKernelGateway', () => {
+  const timers = new Map<string, TimerProto>();
+  let server: grpc.Server;
+  let address: string;
+  let proto: any;
+
+  beforeAll(async () => {
+    proto = loadProto();
+    server = new grpc.Server();
+
+    const serviceImplementation = {
+      scheduleTimer(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+        const fireTime = call.request.fireTime ?? nowTimestamp();
+        const id = call.request.clientTimerId || randomUUID();
+        const timer: TimerProto = {
+          id,
+          tenantId: call.request.tenantId,
+          requestedBy: call.request.requestedBy,
+          name: call.request.name || 'scheduled-from-test',
+          durationMs: Number(call.request.durationMs || '0'),
+          createdAt: nowTimestamp(),
+          fireAt: fireTime,
+          metadata: call.request.metadata,
+          labels: call.request.labels,
+          status: 'TIMER_STATUS_SCHEDULED',
+        };
+        timers.set(`${timer.tenantId}:${id}`, timer);
+        callback(null, { timer });
+      },
+      cancelTimer(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+        const key = `${call.request.tenantId}:${call.request.timerId}`;
+        const timer = timers.get(key);
+        if (!timer) {
+          return callback({ code: grpc.status.NOT_FOUND } as grpc.ServiceError, null);
+        }
+        const cancelled = {
+          ...timer,
+          status: 'TIMER_STATUS_CANCELLED',
+          cancelledAt: nowTimestamp(),
+        };
+        timers.set(key, cancelled);
+        callback(null, cancelled);
+      },
+      getTimer(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+        const key = `${call.request.tenantId}:${call.request.timerId}`;
+        const timer = timers.get(key);
+        if (!timer) {
+          return callback({ code: grpc.status.NOT_FOUND } as grpc.ServiceError, null);
+        }
+        callback(null, timer);
+      },
+      listTimers(call: grpc.ServerUnaryCall<any, any>, callback: grpc.sendUnaryData<any>) {
+        const list = Array.from(timers.values()).filter(
+          (timer) => timer.tenantId === call.request.tenantId,
+        );
+        callback(null, { timers: list, nextPageToken: '' });
+      },
+    } satisfies Record<string, unknown>;
+
+    const service = proto.minoots.timer.v1.HorologyKernel.service;
+    server.addService(service, serviceImplementation);
+
+    await new Promise<void>((resolve, reject) => {
+      server.bindAsync(
+        '127.0.0.1:0',
+        grpc.ServerCredentials.createInsecure(),
+        (err, port) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          address = `127.0.0.1:${port}`;
+          server.start();
+          resolve();
+        },
+      );
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => server.tryShutdown(resolve));
+  });
+
+  const timerRecord = (): TimerRecord => ({
+    id: randomUUID(),
+    tenantId: 'tenant-1',
+    requestedBy: 'agent-1',
+    name: 'integration-test',
+    durationMs: 5_000,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    fireAt: '2024-01-01T00:00:05.000Z',
+    status: 'scheduled',
+    metadata: { foo: 'bar' },
+    labels: { env: 'test' },
+  });
+
+  it('round-trips schedule responses through the gateway', async () => {
+    const gateway = new GrpcKernelGateway(address, PROTO_PATH);
+    const scheduled = await gateway.schedule(timerRecord());
+    expect(scheduled?.tenantId).toBe('tenant-1');
+    expect(scheduled?.metadata).toEqual({ foo: 'bar' });
+  });
+
+  it('lists timers from the gRPC service', async () => {
+    const gateway = new GrpcKernelGateway(address, PROTO_PATH);
+    await gateway.schedule(timerRecord());
+    const timersForTenant = await gateway.list('tenant-1');
+    expect(timersForTenant.length).toBeGreaterThan(0);
+    expect(timersForTenant[0].tenantId).toBe('tenant-1');
+  });
+});
+
+const nowTimestamp = () => {
+  const millis = Date.now();
+  const seconds = Math.floor(millis / 1000);
+  return { seconds: seconds.toString(), nanos: (millis - seconds * 1000) * 1_000_000 };
+};

--- a/docs/DEVELOPMENT_TRACK.md
+++ b/docs/DEVELOPMENT_TRACK.md
@@ -25,10 +25,10 @@ it locally, and lays out the phased backlog that the team can execute immediatel
 
 ## 3. Sprint 0 (Foundations) Deliverables
 The repository now contains the baseline code required to launch the platform locally:
-- **Control Plane service** (`apps/control-plane`) with Express + Zod validation, a timer service layer, and an in-memory
-  repository ready to swap for Postgres.
-- **Horology Kernel crate** (`services/horology-kernel`) implementing an async scheduler with Tokio, broadcast timer events, and
-  cancellation semantics.
+- **Control Plane service** (`apps/control-plane`) with Express + Zod validation, a timer service layer, and a file-backed
+  repository (`TIMER_STORE_PATH`) ready to swap for Postgres.
+- **Horology Kernel crate** (`services/horology-kernel`) implementing an async scheduler with Tokio, optional JSON persistence
+  (`KERNEL_PERSIST_PATH`), broadcast timer events, and NATS publishing.
 - **Action Orchestrator service** (`services/action-orchestrator`) that listens to timer events, performs HTTP/webhook actions,
   and records execution traces.
 - **Shared protobuf** (`proto/timer.proto`) describing the kernel RPC surface and event envelopes.
@@ -51,9 +51,11 @@ Each of these deliverables includes inline documentation and starter scripts so 
    - `cd services/action-orchestrator && npm install`
    - `cd services/horology-kernel && cargo build`
 3. **Run the stack locally**
-   - Control plane: `npm run dev` inside `apps/control-plane` (listens on `localhost:4000`).
-   - Horology kernel: `cargo run --bin kernel` (spawns scheduler and exposes gRPC/TCP placeholder).
-   - Action orchestrator: `npm run dev` inside `services/action-orchestrator` (subscribes to local NATS or in-process queue).
+   - Control plane: `npm run dev` inside `apps/control-plane` (listens on `localhost:4000`). Set `TIMER_STORE_PATH` and
+     `KERNEL_GRPC_ADDRESS` to enable persistence + gRPC.
+   - Horology kernel: `cargo run --bin kernel` (spawns scheduler and exposes gRPC). Configure `KERNEL_PERSIST_PATH` for
+     on-disk recovery and `NATS_URL` to publish timer events.
+   - Action orchestrator: `npm run dev` inside `services/action-orchestrator` (subscribes to local NATS or STDIN fallback).
    - Use the CLI (`independent-timer.js`) or HTTP calls to create timers and observe events flowing through the services.
 4. **Testing cadence** – Each service ships its own unit tests (`npm test` / `cargo test`). Scenario tests in `tests/` will evolve
    to orchestrate the full workflow once persistence is wired up.

--- a/services/horology-kernel/Cargo.lock
+++ b/services/horology-kernel/Cargo.lock
@@ -42,6 +42,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-nats"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea7b126ebfa4db78e9e788b2a792b6329f35b4f2fdd56dbc646dedc2beec7a5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "portable-atomic",
+ "rand",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +180,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +223,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -201,10 +258,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -235,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,12 +447,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -266,6 +484,12 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -285,10 +509,25 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -362,6 +601,7 @@ name = "horology-kernel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-nats",
  "chrono",
  "futures-core",
  "prost",
@@ -473,6 +713,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +959,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "log",
+ "rand",
+ "signatory",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +981,21 @@ checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -637,6 +1020,21 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -685,6 +1083,37 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -842,10 +1271,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -861,6 +1313,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +1379,44 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -916,6 +1462,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +1514,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -972,6 +1571,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1608,17 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -1031,6 +1663,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1744,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,7 +1788,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "h2",
  "http",
@@ -1235,10 +1919,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1257,6 +1981,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1428,6 +2158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +2237,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +2280,66 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/services/horology-kernel/Cargo.toml
+++ b/services/horology-kernel/Cargo.toml
@@ -8,6 +8,8 @@ description = "Durable timer scheduler core for the MINOOTS platform"
 build = "build.rs"
 
 [dependencies]
+anyhow = "1.0"
+async-nats = "0.34"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/services/horology-kernel/README.md
+++ b/services/horology-kernel/README.md
@@ -5,20 +5,22 @@ low jitter, and resilient eventing for agent workloads.
 
 ## Capabilities in this foundation
 - Asynchronously schedules timers with millisecond precision using Tokio.
-- Emits lifecycle events (scheduled, fired, cancelled) via a broadcast channel for downstream orchestrators.
-- Supports cancellation semantics with tenant scoping.
-- Provides unit tests that demonstrate timer firing and cancellation behavior.
+- Emits lifecycle events (scheduled, fired, cancelled) via a broadcast channel and optionally publishes to NATS (`NATS_URL`).
+- Supports cancellation semantics with tenant scoping and persists state to disk when `KERNEL_PERSIST_PATH` is provided.
+- Exposes gRPC endpoints defined in `proto/timer.proto` and includes unit tests for schedule/cancel and proto conversions.
 
 ## Running locally
 ```bash
 cd services/horology-kernel
+KERNEL_PERSIST_PATH=/tmp/minoots-kernel.json \
+NATS_URL=nats://localhost:4222 \
 cargo run --bin kernel
 ```
 
-Set `MINOOTS_BOOT_DEMO=1` to automatically schedule a demo timer when the kernel starts. In a production deployment this binary
-will expose gRPC endpoints defined in `proto/timer.proto` and replicate state across nodes.
+Set `MINOOTS_BOOT_DEMO=1` to automatically schedule a demo timer when the kernel starts. Persistence and NATS publishing are
+optional and enabled through the environment variables shown above.
 
 ## Next steps
-- Swap the in-memory map for FoundationDB/Postgres-backed storage.
-- Expose the scheduling APIs over tonic gRPC and integrate with the control plane.
-- Stream events into NATS JetStream instead of the local broadcast channel.
+- Replace JSON persistence with an append-only log or Postgres-backed store and add replay/compaction logic.
+- Build clustering/failover semantics and timer catch-up after downtime.
+- Surface execution results and orchestrator telemetry back through the kernel events/metadata.


### PR DESCRIPTION
## Summary
- replace the control plane's in-memory timer store with an optional file-backed repository and configurable API key loading
- add Vitest coverage for the gRPC gateway and persist-to-disk regression tests
- extend the Rust horology kernel with JSON persistence, NATS event publishing, and updated documentation/status pages

## Testing
- npm test (apps/control-plane)
- cargo test (services/horology-kernel)


------
https://chatgpt.com/codex/tasks/task_e_68d4c9c6602083298d7fd202a857ad86